### PR TITLE
Don't expose error for implicit fallthrough

### DIFF
--- a/instrumentation/metrics_discovery/common/md_calculation.cpp
+++ b/instrumentation/metrics_discovery/common/md_calculation.cpp
@@ -1277,6 +1277,7 @@ TTypedValue_1_0 CMetricsCalculator::CalculateDeltaFunction( TDeltaFunction_1_0 d
         case DELTA_NS_TIME:
             // No 'break' intentional - NS_TIME should be used only for overflow functions, here use as DELTA 32
             deltaFunction.BitsCount = 32;
+            [[clang::fallthrough]];
 
         case DELTA_N_BITS:
             if( deltaFunction.BitsCount <= 64 )


### PR DESCRIPTION
Fix implicit fallthrough error for:
instrumentation/metrics_discovery/common/md_calculation.cpp:1281:9

Change-Id: Iaff3dff0c489d1d69e78f4591e1a778c3e42ba50
Tracked-On:
Sighed-off-by: Fan Yugang <yugang.fan@intel.com>