### PR TITLE
Rename gen_get_device_info to compile with mesa 19.3.3

### DIFF
--- a/instrumentation/metrics_discovery/linux/md_driver_ifc_linux_perf.cpp
+++ b/instrumentation/metrics_discovery/linux/md_driver_ifc_linux_perf.cpp
@@ -2697,7 +2697,7 @@ TCompletionCode CDriverInterfaceLinuxPerf::GetMesaDeviceInfo( const gen_device_i
     // 2. Get MesaDeviceInfo if not cached already
     if( !isMesaDeviceInfoCached )
     {
-        if( !gen_get_device_info( deviceId, &cachedMesaDeviceInfo ) )
+        if( !gen_get_device_info_from_pci_id( deviceId, &cachedMesaDeviceInfo ) )
         {
             MD_LOG( LOG_ERROR, "ERROR: DeviceId not supported" );
             return CC_ERROR_NOT_SUPPORTED;


### PR DESCRIPTION
Mesa 19.3.3 has renamed function gen_get_device_info to a new name
gen_get_device_info_from_pci_id. To compile with the new name, we
also make the changes in mdapi.

Signed-off-by: Chenglei Ren <chenglei.ren@intel.com>
Tracked-On: OAM-89727
Change-Id: Ic3d5fc7846235a47b4ae38e4f83aac12a1ead0ed