### PR TITLE
Fix compile issues on mesa 22.0.3

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -33,8 +33,11 @@ LOCAL_SRC_FILES += instrumentation/metrics_discovery/codegen/md_main_BXT.cpp \
 				   instrumentation/metrics_discovery/linux/md_driver_ifc_linux_perf.cpp \
 				   instrumentation/utils/common/iu_debug.c \
 				   instrumentation/utils/linux/iu_std_linux.cpp \
-				   ../mesa3d-intel/src/intel/dev/gen_device_info.c \
-				   ../mesa3d-intel/src/util/log.c
+				   ../mesa3d-intel/src/intel/dev/intel_device_info.c \
+				   ../mesa3d-intel/src/util/log.c \
+				   ../mesa3d-intel/src/util/ralloc.c \
+				   ../mesa3d-intel/src/util/u_printf.cpp \
+				   ../mesa3d-intel/src/util/debug.c
 
 LOCAL_CPPFLAGS := -DNDEBUG \
 				  -DINCLUDE_ALL_METRICS \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ set (LOCAL_SRC_FILES ${LOCAL_SRC_FILES}
     ${BS_DIR_INSTRUMENTATION}/utils/common/iu_debug.c
     ${BS_DIR_INSTRUMENTATION}/utils/linux/iu_std_linux.cpp
     # external
-    ${BS_DIR_EXTERNAL}/mesa/src/intel/common/gen_device_info.c
+    ${BS_DIR_EXTERNAL}/mesa/src/intel/common/intel_device_info.c
 )
 
 # mdapi internal files

--- a/instrumentation/metrics_discovery/linux/inc/md_driver_ifc_linux_perf.h
+++ b/instrumentation/metrics_discovery/linux/inc/md_driver_ifc_linux_perf.h
@@ -34,7 +34,7 @@
 
 #include "md_driver_ifc.h"
 
-#include "gen_device_info.h"    // MESA
+#include "intel_device_info.h"    // MESA
 
 using namespace MetricsDiscovery;
 
@@ -181,7 +181,7 @@ private:
     TCompletionCode SendGetParamIoctl( int32_t drmFd, uint32_t paramId, int32_t* outValue );
 
     // Device info params
-    TCompletionCode GetMesaDeviceInfo( const gen_device_info** mesaDeviceInfo );
+    TCompletionCode GetMesaDeviceInfo( const intel_device_info** mesaDeviceInfo );
     TCompletionCode GetDeviceId( int32_t* deviceId );
     TCompletionCode GetInstrPlatformId( GTDI_PLATFORM_INDEX* instrPlatformId );
     TCompletionCode GetGpuFrequencyInfo( uint64_t* minFrequency, uint64_t* maxFrequency, uint64_t* actFrequency, uint64_t* boostFrequency );
@@ -193,7 +193,7 @@ private:
 
     // Device info utils
     uint32_t        GetGtMaxSubslicePerSlice();
-    TCompletionCode MapMesaToInstrPlatform( const gen_device_info* mesaDeviceInfo, GTDI_PLATFORM_INDEX* outInstrPlatformId );
+    TCompletionCode MapMesaToInstrPlatform( const intel_device_info* mesaDeviceInfo, GTDI_PLATFORM_INDEX* outInstrPlatformId );
     TGfxGtType      MapMesaToInstrGtType( int32_t mesaGtType );
 
     // General utils


### PR DESCRIPTION
Including:

1. Rename gen_device_info to intel_device_info following mesa upstream change
2. Replace the way to get deviceName as mesa upstream changed previous function
3. Fix undefined symbol errors for ralloc functions, u_printf_length, env_var_as_boolean
4. Follow rule of mesa upstream to move away from booleans to identify platforms

Signed-off-by: lyintel <yang.a.lu@intel.com>
Tracked-On: OAM-102293